### PR TITLE
Update renderer to use emissive color methods

### DIFF
--- a/Runtime/MaterialConverter.cs
+++ b/Runtime/MaterialConverter.cs
@@ -154,5 +154,17 @@ namespace VisualPinball.Unity.Urp
 		{
 			// todo
 		}
+
+		public void SetEmissiveColor(MaterialPropertyBlock propBlock, Color color)
+		{
+			// urp has no emissive color
+		}
+
+		public Color? GetEmissiveColor(Material material)
+		{
+			// urp has no emissive color
+
+			return null;
+		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "Unity",
     "URP"
   ],
-  "unity": "2020.2",
-  "unityRelease": "0b12",
+  "unity": "2021.2",
+  "unityRelease": "7f1",
   "dependencies": {
-    "com.unity.render-pipelines.universal": "10.2.1",
-    "org.visualpinball.engine.unity": "0.0.1-preview.83"
+    "com.unity.render-pipelines.universal": "12.1.2",
+    "org.visualpinball.engine.unity": "0.0.1-preview.85"
   },
   "author": "freezy <freezy@vpdb.io>",
   "contributors": [


### PR DESCRIPTION
This PR updates the renderer to implement the new emissive color methods added to the `IMaterialConverter` interface.

URP does not currently support emissive color. Without this patch, entering the player currently is crashing when a lamp is turned on or off.

Refer to https://github.com/freezy/VisualPinball.Engine/pull/367 for additional information.