### PR TITLE
Adapt emissive intensity API changes

### DIFF
--- a/Runtime/MaterialConverter.cs
+++ b/Runtime/MaterialConverter.cs
@@ -166,5 +166,17 @@ namespace VisualPinball.Unity.Urp
 
 			return null;
 		}
+
+		public void SetEmissiveIntensity(Material material, MaterialPropertyBlock propBlock, float intensity)
+		{
+			// urp has no emissive intensity
+		}
+
+		public float GetEmissiveIntensity(Material material)
+		{
+			// urp has no emissive intensity
+			//
+			return 0;
+		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "Unity",
     "URP"
   ],
-  "unity": "2021.2",
-  "unityRelease": "7f1",
+  "unity": "2021.3",
+  "unityRelease": "0f1",
   "dependencies": {
-    "com.unity.render-pipelines.universal": "12.1.2",
+    "com.unity.render-pipelines.universal": "12.1.6",
     "org.visualpinball.engine.unity": "0.0.1-preview.106"
   },
   "author": "freezy <freezy@vpdb.io>",


### PR DESCRIPTION
This PR adds `SetEmissiveIntensity` and `GetEmissiveIntensity` methods to the `MaterialConverter`. 

These methods were introduced as part of https://github.com/freezy/VisualPinball.Engine/pull/387 - https://github.com/freezy/VisualPinball.Engine/pull/387/commits/b7ff232e6a44e12174c893ef6124533b5084cb35

